### PR TITLE
Set abort lock true such that transactions are rescheduled properly.

### DIFF
--- a/protocol/Aria/Aria.h
+++ b/protocol/Aria/Aria.h
@@ -28,7 +28,7 @@ public:
 
   void abort(TransactionType &txn,
              std::vector<std::unique_ptr<Message>> &messages) {
-    // nothing needs to be done
+    txn.abort_lock = true
   }
 
   bool commit(TransactionType &txn,


### PR DESCRIPTION
Currently transactions that abort are note being rescheduled. 

In AriaManager line 139 function `cleanup_batch` takes care of rescheduling transactions that abort for the next epoch. Line 145: every transaction that has abort_lock is true will be rescheduled for execution next epoch. However now transactions will never be marked `abort_lock` since nothing is done when aborting the transactions. This PR fixes transactions not being rescheduled by marking them abort_locked when aborting.